### PR TITLE
async/await support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,14 @@ ethernet = []
 "socket-udp" = []
 "socket-tcp" = []
 "socket-icmp" = []
+"async" = []
 default = [
   "std", "log", # needed for `cargo test --no-default-features --features default` :/
   "ethernet",
   "phy-raw_socket", "phy-tap_interface",
   "proto-ipv4", "proto-igmp", "proto-ipv6",
-  "socket-raw", "socket-icmp", "socket-udp", "socket-tcp"
+  "socket-raw", "socket-icmp", "socket-udp", "socket-tcp",
+  "async"
 ]
 
 # experimental; do not use; no guarantees provided that this feature will be kept

--- a/src/socket/mod.rs
+++ b/src/socket/mod.rs
@@ -26,7 +26,12 @@ mod tcp;
 mod set;
 mod ref_;
 
+#[cfg(feature = "async")]
+mod waker_store;
+
 pub(crate) use self::meta::Meta as SocketMeta;
+#[cfg(feature = "async")]
+pub(crate) use self::waker_store::WakerStore;
 
 #[cfg(feature = "socket-raw")]
 pub use self::raw::{RawPacketMetadata,

--- a/src/socket/waker_store.rs
+++ b/src/socket/waker_store.rs
@@ -1,0 +1,23 @@
+use core::task::Waker;
+
+#[derive(Debug)]
+pub struct WakerStore {
+    waker: Option<Waker>,
+}
+
+impl WakerStore {
+    pub const fn new() -> Self {
+        Self { waker: None }
+    }
+
+    pub fn register(&mut self, w: &Waker) {
+        match self.waker {
+            Some(ref w2) if (w2.will_wake(w)) => {}
+            _ => self.waker = Some(w.clone()),
+        }
+    }
+
+    pub fn wake(&mut self) {
+        self.waker.take().map(|w| w.wake());
+    }
+}


### PR DESCRIPTION
This adds support for using TcpSocket with async/await code. If the approach proves good I'll add wakers to the other sockets too.

The approach is to do the minimum required changes to core smoltcp, which allow making higher-level wrappers that can be used with async/await. This way smoltcp can stay un-opinionated:
- The `no_std` ecosystem hasn't converged on any standard io traits yet. The Rust standard is `futures::io::{AsyncRead/AsyncWrite}`, but these aren't `no_std` compatible. 
- There are non-trivial tradeoffs when implementing the wrappers (how are sockets allocated, is there a single global tcp/ip stack or multiple, how are lifetimes handled).

I'm working on PoC wrappers, will report back soon!